### PR TITLE
base: Allow setting preferred refresh rate [1/2]

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -4520,6 +4520,18 @@ public final class Settings {
          */
         public static final String LOW_POWER_REFRESH_RATE = "low_power_rr_switch";
 
+         /**
+         * The user selected preferred refresh rate in frames per second.
+         *
+         * This defines the refresh rate at which UI will run, provided it
+         * falls in the range of minimum and peak refresh rate.
+         *
+         * If this isn't set, the system falls back to a device specific default.
+         * @hide
+         */
+        @Readable
+        public static final String PREFERRED_REFRESH_RATE = "preferred_refresh_rate";
+
         /**
          * The amount of time in milliseconds before the device goes to sleep or begins
          * to dream after a period of inactivity.  This value is also known as the

--- a/services/core/java/com/android/server/display/DisplayModeDirector.java
+++ b/services/core/java/com/android/server/display/DisplayModeDirector.java
@@ -1120,6 +1120,8 @@ public class DisplayModeDirector {
                 Settings.System.getUriFor(Settings.System.PEAK_REFRESH_RATE);
         private final Uri mMinRefreshRateSetting =
                 Settings.System.getUriFor(Settings.System.MIN_REFRESH_RATE);
+        private final Uri mPreferredRefreshRateSetting =
+                Settings.System.getUriFor(Settings.System.PREFERRED_REFRESH_RATE);
         private final Uri mLowPowerModeSetting =
                 Settings.Global.getUriFor(Settings.Global.LOW_POWER_MODE);
         private final Uri mMatchContentFrameRateSetting =
@@ -1143,7 +1145,11 @@ public class DisplayModeDirector {
         public void observe() {
             final ContentResolver cr = mContext.getContentResolver();
             mInjector.registerPeakRefreshRateObserver(cr, this);
+            cr.registerContentObserver(mPeakRefreshRateSetting, false /*notifyDescendants*/, this,
+                    UserHandle.USER_SYSTEM);
             cr.registerContentObserver(mMinRefreshRateSetting, false /*notifyDescendants*/, this,
+                    UserHandle.USER_SYSTEM);
+            cr.registerContentObserver(mPreferredRefreshRateSetting, false /*notifyDescendants*/, this,
                     UserHandle.USER_SYSTEM);
             cr.registerContentObserver(mLowPowerModeSetting, false /*notifyDescendants*/, this,
                     UserHandle.USER_SYSTEM);
@@ -1190,7 +1196,8 @@ public class DisplayModeDirector {
         public void onChange(boolean selfChange, Uri uri, int userId) {
             synchronized (mLock) {
                 if (mPeakRefreshRateSetting.equals(uri)
-                        || mMinRefreshRateSetting.equals(uri)) {
+                        || mMinRefreshRateSetting.equals(uri)
+                        || mPreferredRefreshRateSetting.equals(uri)) {
                     updateRefreshRateSettingLocked();
                 } else if (mLowPowerModeSetting.equals(uri)
                         || mLowPowerRefreshRateSetting.equals(uri)) {
@@ -1222,7 +1229,9 @@ public class DisplayModeDirector {
                     Settings.System.MIN_REFRESH_RATE, 60.0f, cr.getUserId());
             float peakRefreshRate = Settings.System.getFloatForUser(cr,
                     Settings.System.PEAK_REFRESH_RATE, mDefaultPeakRefreshRate, cr.getUserId());
-            updateRefreshRateSettingLocked(minRefreshRate, peakRefreshRate, mDefaultRefreshRate);
+            float preferredRefreshRate = Settings.System.getFloatForUser(cr,
+                    Settings.System.PREFERRED_REFRESH_RATE, mDefaultRefreshRate, cr.getUserId());
+            updateRefreshRateSettingLocked(minRefreshRate, peakRefreshRate, preferredRefreshRate);
         }
 
         private void updateRefreshRateSettingLocked(


### PR DESCRIPTION
 * also register missing content observer for peak refresh rate while we're at it

Change-Id: I4f494687cef87dc9b24f4c712a8dbdedf1def400
Signed-off-by: Adithya R <gh0strider.2k18.reborn@gmail.com>